### PR TITLE
Nice translation for metabox title

### DIFF
--- a/dynamic-featured-image.php
+++ b/dynamic-featured-image.php
@@ -73,7 +73,7 @@
       $i = 2;                   
       foreach($featuredData as $featured){
         foreach($postTypes as $type) {         
-            add_meta_box('dfiFeaturedMetaBox-'.$i, 'Featured Image ' . $i, 'dfi_featured_meta_box', $type, 'side', 'low', array($featured, $i+1));      
+            add_meta_box('dfiFeaturedMetaBox-'.$i, __( 'Post Thumbnail' ) . ' ' . $i, 'dfi_featured_meta_box', $type, 'side', 'low', array($featured, $i+1));      
             add_filter( "postbox_classes_{$type}_dfiFeaturedMetaBox-".$i, 'add_metabox_classes' );                              
         }
         
@@ -81,7 +81,7 @@
       }
     } else {        
         foreach($postTypes as $type){
-            add_meta_box( 'dfiFeaturedMetaBox', 'Featured Image 2', 'dfi_featured_meta_box', $type, 'side', 'low', array(null, null) );   
+            add_meta_box( 'dfiFeaturedMetaBox', __( 'Post Thumbnail' ) . ' 2', 'dfi_featured_meta_box', $type, 'side', 'low', array(null, null) );   
             add_filter( "postbox_classes_{$type}_dfiFeaturedMetaBox", 'add_metabox_classes' );           
         }
     }


### PR DESCRIPTION
Support for nice translated title of metaboxes using WP native localization.

![2013-12-10 16 45 50_800x600](https://f.cloud.github.com/assets/3281210/1713383/7cd16036-6189-11e3-8232-afc09f9f5141.jpg)
