### PR TITLE
fix warning when counting empty string (php 7.2)

### DIFF
--- a/dynamic-featured-image.php
+++ b/dynamic-featured-image.php
@@ -241,7 +241,7 @@ class Dynamic_Featured_Image {
         $this->metabox_title = apply_filters( 'dfi_set_metabox_title', __( 'Featured Image', self::TEXT_DOMAIN ) );
 
         $featured_data  = get_post_meta( $post->ID, 'dfiFeatured', true );
-        $total_featured = count( $featured_data );
+        $total_featured = is_array( $featured_data ) ? count( $featured_data ) : 0;
 
         $default_filter    = array( 'attachment', 'revision', 'nav_menu_item' );
         $this->user_filter = apply_filters( 'dfi_post_type_user_filter', $this->user_filter );


### PR DESCRIPTION
get_post_meta can return an empty string, which emits a warning when tried to be counted since php 7.2

Fixes #65 